### PR TITLE
Use Definitions instead File

### DIFF
--- a/traits/ComponentUtils.php
+++ b/traits/ComponentUtils.php
@@ -9,6 +9,7 @@ use ApplicationException;
 use System\Models\File;
 use October\Rain\Support\Collection;
 use Exception;
+use October\Rain\Filesystem\Definitions;
 
 trait ComponentUtils
 {
@@ -170,7 +171,7 @@ trait ComponentUtils
         $types = $this->property('fileTypes', '*');
 
         if (!$types || $types == '*') {
-            $types = implode(',', File::getDefaultFileTypes());
+            $types = implode(',', Definitions::get('defaultExtensions'));
         }
 
         if (!is_array($types)) {


### PR DESCRIPTION
`File::getDefaultFileTypes()` was removed in commit [f63db5c67f953dbbd3470058870a9c67d9096f39](https://github.com/octobercms/library/commit/f63db5c67f953dbbd3470058870a9c67d9096f39#diff-b062dfb9a3f1e4c504ad988c977f1b40)

Use `Definitions::get('defaultExtensions')` instead.
