### PR TITLE
Allowing to use custom file upload models

### DIFF
--- a/traits/ComponentUtils.php
+++ b/traits/ComponentUtils.php
@@ -142,7 +142,10 @@ trait ComponentUtils
                 throw new ApplicationException(sprintf('File %s is not valid.', $uploadedFile->getClientOriginalName()));
             }
 
-            $file = new File;
+            $relationType = $this->model->getRelationType($this->attribute);
+            $fileModel = $this->model->{$relationType}[$this->attribute];
+            
+            $file = new $fileModel;
             $file->data = $uploadedFile;
             $file->is_public = true;
             $file->save();

--- a/traits/ComponentUtils.php
+++ b/traits/ComponentUtils.php
@@ -142,8 +142,8 @@ trait ComponentUtils
                 throw new ApplicationException(sprintf('File %s is not valid.', $uploadedFile->getClientOriginalName()));
             }
 
-            $relationType = $this->model->getRelationType($this->attribute);
-            $fileModel = $this->model->{$relationType}[$this->attribute];
+            
+            $fileModel = $this->model->getRelationDefinition($this->attribute)[0];
             
             $file = new $fileModel;
             $file->data = $uploadedFile;


### PR DESCRIPTION
This little change allows to use other file models than the default `System\Models\File`.
