### PR TITLE
Add assets combined

### DIFF
--- a/components/FileUploader.php
+++ b/components/FileUploader.php
@@ -86,9 +86,11 @@ class FileUploader extends ComponentBase
 
     public function onRun()
     {
-        $this->addCss('assets/css/uploader.css');
-        $this->addJs('assets/vendor/dropzone/dropzone.js');
-        $this->addJs('assets/js/uploader.js');
+        $this->addCss(['assets/css/uploader.css']);
+        $this->addJs([
+            'assets/vendor/dropzone/dropzone.js',
+            'assets/js/uploader.js',
+        ]);
 
         $this->autoPopulate();
     }

--- a/components/ImageUploader.php
+++ b/components/ImageUploader.php
@@ -130,9 +130,11 @@ class ImageUploader extends ComponentBase
 
     public function onRun()
     {
-        $this->addCss('assets/css/uploader.css');
-        $this->addJs('assets/vendor/dropzone/dropzone.js');
-        $this->addJs('assets/js/uploader.js');
+        $this->addCss(['assets/css/uploader.css']);
+        $this->addJs([
+            'assets/vendor/dropzone/dropzone.js',
+            'assets/js/uploader.js',
+        ]);
 
         $this->autoPopulate();
     }


### PR DESCRIPTION
Added combined for js and css files. In this case, when changing the resource files, the new version will be loaded, not the cached version.

P.S. After the last update, many users downloaded the old version of javascript file from browser cache and the plugin stopped working.