### PR TITLE
Move to trait and confirm file_id is attached

### DIFF
--- a/components/FileUploader.php
+++ b/components/FileUploader.php
@@ -1,4 +1,6 @@
-<?php namespace Responsiv\Uploader\Components;
+<?php
+
+namespace Responsiv\Uploader\Components;
 
 use Input;
 use Cms\Classes\ComponentBase;
@@ -103,8 +105,7 @@ class FileUploader extends ComponentBase
 
         if ($populated = $this->property('populated')) {
             $this->setPopulated($populated);
-        }
-        else {
+        } else {
             $this->autoPopulate();
         }
     }
@@ -120,12 +121,5 @@ class FileUploader extends ComponentBase
         $file->pathUrl = $file->thumbUrl = $file->getPath();
 
         return $file;
-    }
-
-    public function onRemoveAttachment()
-    {
-        if (($file_id = post('file_id')) && ($file = File::find($file_id))) {
-            $this->model->{$this->attribute}()->remove($file, $this->getSessionKey());
-        }
     }
 }

--- a/components/ImageUploader.php
+++ b/components/ImageUploader.php
@@ -1,4 +1,6 @@
-<?php namespace Responsiv\Uploader\Components;
+<?php
+
+namespace Responsiv\Uploader\Components;
 
 use System\Models\File;
 use Cms\Classes\ComponentBase;
@@ -160,20 +162,19 @@ class ImageUploader extends ComponentBase
 
         if ($mode == 'block') {
             $cssDimensions .= ($this->imageWidth)
-                ? 'width: '.$this->imageWidth.'px;'
-                : 'width: '.$this->imageHeight.'px;';
+                ? 'width: ' . $this->imageWidth . 'px;'
+                : 'width: ' . $this->imageHeight . 'px;';
 
             $cssDimensions .= ($this->imageHeight)
-                ? 'height: '.$this->imageHeight.'px;'
+                ? 'height: ' . $this->imageHeight . 'px;'
                 : 'height: auto;';
-        }
-        else {
+        } else {
             $cssDimensions .= ($this->imageWidth)
-                ? 'width: '.$this->imageWidth.'px;'
+                ? 'width: ' . $this->imageWidth . 'px;'
                 : 'width: auto;';
 
             $cssDimensions .= ($this->imageHeight)
-                ? 'height: '.$this->imageHeight.'px;'
+                ? 'height: ' . $this->imageHeight . 'px;'
                 : 'height: auto;';
         }
 
@@ -192,8 +193,7 @@ class ImageUploader extends ComponentBase
 
         if (!empty($this->imageWidth) || !empty($this->imageHeight)) {
             $thumb = $file->getThumb($this->imageWidth, $this->imageHeight, $this->thumbOptions);
-        }
-        else {
+        } else {
             $thumb = $file->getThumb(63, 63, $this->thumbOptions);
         }
 
@@ -211,16 +211,8 @@ class ImageUploader extends ComponentBase
 
         if ($populated = $this->property('populated')) {
             $this->setPopulated($populated);
-        }
-        else {
+        } else {
             $this->autoPopulate();
-        }
-    }
-
-    public function onRemoveAttachment()
-    {
-        if (($file_id = post('file_id')) && ($file = File::find($file_id))) {
-            $this->model->{$this->attribute}()->remove($file, $this->getSessionKey());
         }
     }
 }

--- a/traits/ComponentUtils.php
+++ b/traits/ComponentUtils.php
@@ -1,4 +1,6 @@
-<?php namespace Responsiv\Uploader\Traits;
+<?php
+
+namespace Responsiv\Uploader\Traits;
 
 use Input;
 use Request;
@@ -56,7 +58,7 @@ trait ComponentUtils
     {
         $list = $this->isMulti ? $model : new Collection([$model]);
 
-        $list->each(function($file) {
+        $list->each(function ($file) {
             $this->decorateFileAttributes($file);
         });
 
@@ -88,8 +90,7 @@ trait ComponentUtils
                 ->withDeferred($sessionKey)
                 ->orderBy('id', 'desc')
                 ->get();
-        }
-        else {
+        } else {
             $list = $this->model
                 ->{$this->attribute}()
                 ->orderBy('id', 'desc')
@@ -103,7 +104,7 @@ trait ComponentUtils
         /*
          * Decorate each file with thumb
          */
-        $list->each(function($file) {
+        $list->each(function ($file) {
             $this->decorateFileAttributes($file);
         });
 
@@ -120,9 +121,9 @@ trait ComponentUtils
             $uploadedFile = Input::file('file_data');
 
 
-            $validationRules = ['max:'.$this->getMaxFileSize()];
+            $validationRules = ['max:' . $this->getMaxFileSize()];
             if ($fileTypes = $this->processFileTypes()) {
-                $validationRules[] = 'extensions:'.$fileTypes;
+                $validationRules[] = 'extensions:' . $fileTypes;
             }
 
             $validation = Validator::make(
@@ -158,12 +159,36 @@ trait ComponentUtils
             ];
 
             return Response::json($result, 200);
-
-        }
-        catch (Exception $ex) {
+        } catch (Exception $ex) {
             return Response::json($ex->getMessage(), 400);
         }
     }
+
+    public function onRemoveAttachment()
+    {
+        if (!$file_id = post('file_id')) {
+            return;
+        }
+
+        /*
+         * Use deferred bindings
+         */
+        if ($sessionKey = $this->getSessionKey()) {
+            $file = $this->model
+                ->{$this->attribute}()
+                ->withDeferred($sessionKey)
+                ->find($file_id);
+        } else {
+            $file = $this->model
+                ->{$this->attribute}()
+                ->find($file_id);
+        }
+
+        if ($file) {
+            $this->model->{$this->attribute}()->remove($file, $this->getSessionKey());
+        }
+    }
+
 
     public function getSessionKey()
     {
@@ -190,7 +215,7 @@ trait ComponentUtils
             $types = explode(',', $types);
         }
 
-        $types = array_map(function($value) use ($includeDot) {
+        $types = array_map(function ($value) use ($includeDot) {
             $value = trim($value);
 
             if (substr($value, 0, 1) == '.') {
@@ -198,7 +223,7 @@ trait ComponentUtils
             }
 
             if ($includeDot) {
-                $value = '.'.$value;
+                $value = '.' . $value;
             }
 
             return $value;
@@ -215,8 +240,7 @@ trait ComponentUtils
     {
         if ($maxSize = $this->property('maxSize')) {
             return round($maxSize * 1024);
-        }
-        else {
+        } else {
             return File::getMaxFilesize();
         }
     }


### PR DESCRIPTION
Move duplicate onRemoveAttachment method to trait.  Update onRemoveAttachment method to check if the posted file_id is attached to $model.  Otherwise, file_id post value can be manipulated and any system_file record deleted.

Might be better to update the AttachOneOrMany [remove method](https://github.com/octobercms/library/blob/60fb094158280835caf4045729448bec2398d56c/src/Database/Relations/AttachOneOrMany.php#L235) to confirm the file is attached before deleting or unbindDeferred